### PR TITLE
Fix Database Startup Error during tests

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,10 +2,10 @@ spring.servlet.multipart.max-file-size=10MB
 #Config for MySQL DB
 spring.datasource.url=jdbc:mysql://localhost:3306/caterest
 spring.datasource.username=root
-spring.datasource.password=da040603
+spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database=mysql
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 #End Config
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,12 +1,10 @@
-spring.datasource.url=jdbc:h2://mem:db;DB_CLOSE_DELAY=-1
-#spring.datasource.url=jdbc:h2:mem:test_db
-spring.datasource.username=sa
-spring.datasource.password=sa
+spring.datasource.url=jdbc:h2:mem:test_db
+spring.datasource.username=root
+spring.datasource.password=root
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.properties.hibernate.format_sql=true
-
 spring.servlet.multipart.max-file-size=10MB
 server.error.include-message=always


### PR DESCRIPTION
Exceptions are caused by ```spring.jpa.hibernate.ddl-auto=create-drop``` , it can be fixed by changing the property value to ```create```, but ```create-drop```  does not affect the application execution so it will be kept. 

When running application tests, the ```contextLoads``` test was failing because the database url was bad formatted, therefore changed the url property value to ```jdbc:h2:mem:test_db``` to allow test to succeed.